### PR TITLE
fix for issue #83

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -71,7 +71,7 @@ incremental: true
 collections:
   tracks:
     output: true
-    permalink: /tracks/:title/
+    permalink: /tracks/:path/
   albums:
     output: true
     permalink: /albums/:title/

--- a/jekyll/_includes/variables.liquid
+++ b/jekyll/_includes/variables.liquid
@@ -7,6 +7,7 @@
   {% assign all_tracks_on_album = album.Tracks | sort: "Track_Number" %}
   {% assign matched_album_year = album.Year %}
   {% assign matched_album_usb_dir = album.USB_Directory %}
+  {% assign matched_album_slug = album.Album_Slug %}
 {% endfor %}
 
 {% assign matched_track = all_tracks_on_album | where_exp: "item", "item.Track_Title == page.track_title" %}

--- a/jekyll/_layouts/album.html
+++ b/jekyll/_layouts/album.html
@@ -11,7 +11,7 @@ layout: page
     <li style="list-style-type: none;">
       <strong>{{ track.Track_Number }}: </strong>
       {% if track %}
-        <a href="{{ site.baseurl }}/tracks/{{ track.Track_Slug }}">{{ track.Track_Title }}</a>
+        <a href="{{ site.baseurl }}/tracks/{{ matched_album_slug }}/{{ track.Track_Slug }}">{{ track.Track_Title }}</a>
       {% else %}
         {{ track.Track_Title }} (track not found)
       {% endif %}

--- a/jekyll/_plugins/generate_track_pages.rb
+++ b/jekyll/_plugins/generate_track_pages.rb
@@ -18,9 +18,16 @@ module Jekyll
       private
   
       def create_track_doc(site, album_data, track_data)
-        slug = Jekyll::Utils.slugify(track_data['track_title'])
-        filename = "#{slug}.md"
-        path = File.join(site.source, '_tracks', filename)
+        track_slug = Jekyll::Utils.slugify(track_data['track_title'])
+        album_slug = Jekyll::Utils.slugify(album_data['album'])
+        
+        # Create album subfolder path
+        album_dir = File.join('_tracks', album_slug)
+        # Create full directory path if it doesn't exist
+        FileUtils.mkdir_p(File.join(site.source, album_dir)) unless Dir.exist?(File.join(site.source, album_dir))
+        
+        filename = "#{track_slug}.md"
+        path = File.join(site.source, album_dir, filename)
         doc = Document.new(path, { :site => site, :collection => site.collections['tracks'] })
         doc.data['album_title'] = album_data['album']
         doc.data['album_year'] = album_data['year']

--- a/jekyll/_plugins/load_json_data.rb
+++ b/jekyll/_plugins/load_json_data.rb
@@ -18,7 +18,7 @@ module Jekyll
           json_data = parse_json_safely(File.read(file))
           site.data[data_key] = json_data
         end
-        data_file_path = File.join(json_dir, 'data.json')
+        data_file_path = File.join(json_dir, 'combined_data.json')
         puts "\e[32mLoading data from #{data_file_path}\e[0m"
 
         if File.exist?(data_file_path)

--- a/jekyll/_plugins/update_yml.rb
+++ b/jekyll/_plugins/update_yml.rb
@@ -6,7 +6,7 @@ module Jekyll
 
     def generate(site)
       start_time = Time.now  # added timer start
-      data_file = File.join(site.source, "assets", 'json', 'data.json') 
+      data_file = File.join(site.source, "assets", 'json', 'data.json')
       json_data = JSON.parse(File.read(data_file))
       updated_yaml = json_data.to_yaml
       target_file = File.join(site.source, '_data', 'data.yml')


### PR DESCRIPTION
some tracks within the discography have the same name but are on different albums, so pages generated between those weren't output properly; generated track pages were all placed into the `/tracks` folder, now they are placed into a subfolder of `/tracks` with the subfolder's name being the track's respective album

the side effect of this for now is that rendering the site is slow again because `load_json_data.rb` has to load `combined_data.json` instead of the smaller `data.json`, but loading `data.json` reintroduces the issue