### PR TITLE
v1.3.0

### DIFF
--- a/.github/workflows/publish-for-netlify.yml
+++ b/.github/workflows/publish-for-netlify.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g., v1.2.0)'
+        description: 'Version tag to publish'
         required: true
-        default: 'v1.2.0'
+        default: 'v1.3.0'
 
 # Define a job named `build-and-publish` in your workflow.
 jobs:
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checkout the v1.2.0 tag when triggered by push to main
+      # Checkout the specific version tag when triggered by push to main
       # or use the specified tag when manually triggered
       - name: Checkout specific tag
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.tag || 'v1.2.0' }}
+          ref: ${{ github.event.inputs.tag || 'v1.3.0' }}
 
       # Set up Ruby for Jekyll.
       - uses: ruby/setup-ruby@v1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -18,8 +18,8 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-loadIndividualTrackJSON: true
-render_quickly: false
+loadIndividualTrackJSON: false
+render_quickly: true
 
 exclude:
   - Gemfile

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -18,8 +18,8 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-loadIndividualTrackJSON: false
-render_quickly: true
+loadIndividualTrackJSON: true
+render_quickly: false
 
 exclude:
   - Gemfile

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -40,7 +40,7 @@ async function loadData() {
             for(const album of albums) {
                 console.log("Loading album: " + album.Album);
                 for (const track of album.Tracks) {
-                    const jsonPath = "/assets/json/"+album.Album_Slug+"/"+track.Track_JSONPath;
+                    const jsonPath = BASE_URL+"/assets/json/"+album.Album_Slug+"/"+track.Track_JSONPath;
                     trackSubtitlesData = await fetchData(jsonPath);
                     for (const subtitle of trackSubtitlesData) {
                         dataStructure.push({

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -32,7 +32,7 @@ async function loadData() {
     
     if (loadIndividualTrackJSON === true) {
         console.log("--Loading data from data.json and the individual track JSON files--");
-        const data = await fetchData(BASE_URL+'/assets/json/data.json');
+        const data = await fetchData(BASE_URL+"/assets/json/data.json");
 
         // Iterate through each album, track, and subtitle
         for (const albumsKey of Object.keys(data)) {
@@ -67,7 +67,7 @@ async function loadData() {
 
     } else {
         console.log("--Loading data from combined_data.json--");
-        const data = await fetchData(BASE_URL+'/assets/json/combined_data.json');
+        const data = await fetchData(BASE_URL+"/assets/json/combined_data.json");
 
         // Iterate through each album, track, and subtitle
         for (const albumsKey of Object.keys(data)) {

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -1,11 +1,13 @@
-/*
 ---
-layout: null
+
 ---
-*/
 
 // search.js
 const BASE_URL = '{{ site.baseurl }}';
+//console.log("BASE_URL: " + BASE_URL);
+const loadIndividualTrackJSON = '{{ site.loadIndividualTrackJSON }}';
+//console.log("loadIndividualTrackJSON: " + loadIndividualTrackJSON);
+
 /*
     This function retrieves a JSON document from a given path
 */
@@ -25,11 +27,11 @@ async function fetchData(path) {
 async function loadData() {
 
     let dataStructure = [];
-    var loadIndividualTrackJSON = '{{ site.loadIndividualTrackJSON }}';
+    
     var jekyll_env = '{{ jekyll.environment }}';
     
     if (loadIndividualTrackJSON === true) {
-        console.log("Loading data from individual JSON files...");
+        console.log("--Loading data from data.json and the individual track JSON files--");
         const data = await fetchData('/assets/json/data.json');
 
         // Iterate through each album, track, and subtitle
@@ -64,8 +66,7 @@ async function loadData() {
         }
 
     } else {
-        console.log("Using combined_data.json");
-        console.log(loadIndividualTrackJSON);
+        console.log("--Loading data from combined_data.json--");
         const data = await fetchData('/assets/json/combined_data.json');
 
         // Iterate through each album, track, and subtitle

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -32,7 +32,7 @@ async function loadData() {
     
     if (loadIndividualTrackJSON === true) {
         console.log("--Loading data from data.json and the individual track JSON files--");
-        const data = await fetchData('/assets/json/data.json');
+        const data = await fetchData(BASE_URL+'/assets/json/data.json');
 
         // Iterate through each album, track, and subtitle
         for (const albumsKey of Object.keys(data)) {
@@ -67,7 +67,7 @@ async function loadData() {
 
     } else {
         console.log("--Loading data from combined_data.json--");
-        const data = await fetchData('/assets/json/combined_data.json');
+        const data = await fetchData(BASE_URL+'/assets/json/combined_data.json');
 
         // Iterate through each album, track, and subtitle
         for (const albumsKey of Object.keys(data)) {

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -5,7 +5,7 @@
 // search.js
 const BASE_URL = '{{ site.baseurl }}';
 console.log("BASE_URL: " + (BASE_URL ? BASE_URL : "<null>"));
-const loadIndividualTrackJSON = '{{ site.loadIndividualTrackJSON }}';
+const loadIndividualTrackJSON = '{{ site.loadIndividualTrackJSON }}' === 'true';
 console.log("loadIndividualTrackJSON: " + loadIndividualTrackJSON);
 
 /*
@@ -30,7 +30,7 @@ async function loadData() {
     
     var jekyll_env = '{{ jekyll.environment }}';
     
-    if (loadIndividualTrackJSON === true) {
+    if (loadIndividualTrackJSON) {
         console.log("--Loading data from data.json and the individual track JSON files--");
         const data = await fetchData(BASE_URL+"/assets/json/data.json");
 

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -4,9 +4,9 @@
 
 // search.js
 const BASE_URL = '{{ site.baseurl }}';
-//console.log("BASE_URL: " + BASE_URL);
+console.log("BASE_URL: " + (BASE_URL ? BASE_URL : "<null>"));
 const loadIndividualTrackJSON = '{{ site.loadIndividualTrackJSON }}';
-//console.log("loadIndividualTrackJSON: " + loadIndividualTrackJSON);
+console.log("loadIndividualTrackJSON: " + loadIndividualTrackJSON);
 
 /*
     This function retrieves a JSON document from a given path


### PR DESCRIPTION
This version adds support for deploying the production site based on a specific version tag. This change is needed so that deployments with the "main" branch can be controlled, as commits to the main branch could potentially introduce bugs and thus using a specific release staggers these kinds of issues.

It also includes a temporary workaround for a bug in loading the site's data, though it reverts to the slower method as seen in previous versions.

Other changes include:

- hide the LPC USB audio player if on mobile
- bring back the navigation menu when on mobile
- stop committing `combined_data.json` to the repo
- deploy the "dev" branch instead of "main" to GitHub Pages