### PR TITLE
make a better LPC USB audio player

### DIFF
--- a/jekyll/_includes/embed-audio-dir-for-search.html
+++ b/jekyll/_includes/embed-audio-dir-for-search.html
@@ -1,2 +1,219 @@
 
-{% include embed-audio.html %}
+<style>
+  #audioFab {
+    position: fixed; bottom: 24px; right: 24px; z-index: 1000;
+    width: 56px; height: 56px; border-radius: 50%;
+    background: #5a5a9a; border: 2px solid #9a9adf;
+    cursor: pointer; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    font-size: 26px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+    transition: transform 0.2s, background 0.2s, box-shadow 0.2s; line-height: 1; gap: 1px;
+  }
+  #audioFabTime {
+    font-size: 8px; color: #d0d0ff; letter-spacing: 0.02em; line-height: 1; display: none;
+  }
+  #audioFab:hover { background: #7a7abf; transform: scale(1.1); box-shadow: 0 6px 18px rgba(0,0,0,0.6); }
+  #audioFabPanel {
+    position: fixed; bottom: 90px; right: 24px; z-index: 999;
+    background: #1e1e3a; border: 1px solid #7a7abf;
+    border-radius: 14px; padding: 16px 18px;
+    box-shadow: 0 8px 28px rgba(0,0,0,0.6);
+    display: none; flex-direction: column; align-items: center; min-width: 300px; gap: 10px;
+  }
+  #audioFabPanel audio { width: 100%; margin-top: 4px; }
+  #audioFabPanel .fab-panel-title { margin: 0; color: #b0b0e0; font-size: 0.78em; text-align: center; }
+</style>
+
+<script>
+(function () {
+  const isMobile = window.innerWidth <= 768 ||
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent);
+  if (isMobile) return;
+
+  const fab = document.createElement('button');
+  fab.id = 'audioFab';
+  fab.title = 'Listen to track';
+  fab.setAttribute('aria-label', 'Listen to track');
+  fab.textContent = '\uD83C\uDFA7';
+  const fabTimeLabel = document.createElement('span');
+  fabTimeLabel.id = 'audioFabTime';
+  fab.appendChild(fabTimeLabel);
+
+  const fabPanel = document.createElement('div');
+  fabPanel.id = 'audioFabPanel';
+
+  const panelTitle = document.createElement('p');
+  panelTitle.className = 'fab-panel-title';
+  panelTitle.textContent = 'Select the top-level directory for the collection, usually named \u201CLPC USB\u201D';
+  fabPanel.appendChild(panelTitle);
+
+  const audioPlayer = document.createElement('audio');
+  audioPlayer.id = 'audioPlayer';
+  audioPlayer.setAttribute('controls', '');
+  audioPlayer.style.display = 'none';
+  fabPanel.appendChild(audioPlayer);
+
+  document.addEventListener('click', function (e) {
+    const searchResults = document.getElementById('subtitles-search-results');
+    if (!fab.contains(e.target) && !fabPanel.contains(e.target) &&
+        !(searchResults && searchResults.contains(e.target))) {
+      fabPanel.style.display = 'none';
+    }
+  });
+
+  function refreshSearch() {
+    const searchInput = document.querySelector('#subtitles-search-input');
+    if (searchInput && searchInput.value.trim() !== '') {
+      searchInput.dispatchEvent(new Event('input'));
+    }
+  }
+
+  if ('showDirectoryPicker' in window) {
+    // IndexedDB helpers — shared with tracks page (same store)
+    function openDb() {
+      return new Promise(function (resolve, reject) {
+        const req = indexedDB.open('lpc-usb-db', 1);
+        req.onupgradeneeded = function (e) { e.target.result.createObjectStore('handles'); };
+        req.onsuccess = function (e) { resolve(e.target.result); };
+        req.onerror = function () { reject(req.error); };
+      });
+    }
+    async function getStoredHandle() {
+      try {
+        const db = await openDb();
+        return await new Promise(function (resolve) {
+          const tx = db.transaction('handles', 'readonly');
+          const get = tx.objectStore('handles').get('lpcUsb');
+          get.onsuccess = function () { resolve(get.result || null); };
+          get.onerror = function () { resolve(null); };
+        });
+      } catch (e) { return null; }
+    }
+    async function storeHandle(handle) {
+      const db = await openDb();
+      return new Promise(function (resolve, reject) {
+        const tx = db.transaction('handles', 'readwrite');
+        tx.objectStore('handles').put(handle, 'lpcUsb');
+        tx.oncomplete = function () { resolve(); };
+        tx.onerror = function () { reject(tx.error); };
+      });
+    }
+
+    // Recursively traverse the LPC USB dir and build window.fileMap
+    async function traverseDir(dirHandle, path) {
+      for await (const [name, entry] of dirHandle.entries()) {
+        const entryPath = path + '/' + name;
+        if (entry.kind === 'file' && name.toLowerCase().endsWith('.mp3')) {
+          const file = await entry.getFile();
+          window.fileMap[entryPath] = URL.createObjectURL(file);
+        } else if (entry.kind === 'directory') {
+          await traverseDir(entry, entryPath);
+        }
+      }
+    }
+
+    async function loadFromDir(dirHandle) {
+      window.fileMap = {};
+      selectBtn.textContent = '\u23F3 Loading\u2026';
+      selectBtn.disabled = true;
+      await traverseDir(dirHandle, 'LPC USB');
+      audioPlayer.style.display = '';
+      selectBtn.textContent = '\u2705 LPC USB loaded';
+      selectBtn.style.borderColor = 'greenyellow';
+      selectBtn.disabled = false;
+      panelTitle.style.display = 'none';
+      audioPlayer.addEventListener('timeupdate', function () {
+        if (audioPlayer.duration) {
+          const s = Math.floor(audioPlayer.currentTime);
+          fabTimeLabel.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+          fabTimeLabel.style.display = '';
+        }
+      });
+      refreshSearch();
+    }
+
+    let cachedHandle = null;
+    getStoredHandle().then(async function (h) {
+      cachedHandle = h;
+      if (!h) return;
+      try {
+        const perm = await h.queryPermission({ mode: 'read' });
+        if (perm === 'granted') {
+          await loadFromDir(h);
+        }
+      } catch (e) {
+        console.warn('Auto-load on page load failed:', e);
+      }
+    });
+
+    const selectBtn = document.createElement('button');
+    selectBtn.id = 'selectLpcBtn';
+    selectBtn.style.cssText = 'color: greenyellow; background: none; border: 1px solid greenyellow; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-weight: bold;';
+    selectBtn.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
+    fabPanel.insertBefore(selectBtn, audioPlayer);
+
+    selectBtn.addEventListener('click', async function () {
+      try {
+        const dirHandle = await window.showDirectoryPicker({ mode: 'read', startIn: 'music' });
+        await storeHandle(dirHandle);
+        cachedHandle = dirHandle;
+        await loadFromDir(dirHandle);
+      } catch (e) {
+        if (e.name !== 'AbortError') console.error(e);
+      }
+    });
+
+    fab.addEventListener('click', async function () {
+      const isOpen = fabPanel.style.display === 'flex';
+      fabPanel.style.display = isOpen ? 'none' : 'flex';
+      if (!isOpen && audioPlayer.style.display === 'none' && cachedHandle) {
+        try {
+          const perm = await cachedHandle.requestPermission({ mode: 'read' });
+          if (perm === 'granted') {
+            await loadFromDir(cachedHandle);
+          }
+        } catch (e) {
+          console.warn('Could not auto-load from stored handle:', e);
+        }
+      }
+    });
+
+  } else {
+    // Fallback: legacy <input webkitdirectory>
+    const fileLabel = document.createElement('label');
+    fileLabel.setAttribute('for', 'fileInput');
+    fileLabel.style.cssText = 'color: greenyellow; cursor: pointer; font-weight: bold;';
+    fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
+    fabPanel.insertBefore(fileLabel, audioPlayer);
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.id = 'fileInput';
+    fileInput.accept = 'audio/mp3';
+    fileInput.setAttribute('webkitdirectory', '');
+    fileInput.multiple = true;
+    fabPanel.insertBefore(fileInput, audioPlayer);
+
+    fab.addEventListener('click', function () {
+      const isOpen = fabPanel.style.display === 'flex';
+      fabPanel.style.display = isOpen ? 'none' : 'flex';
+    });
+
+    fileInput.addEventListener('change', function (event) {
+      window.fileMap = {};
+      const files = event.target.files;
+      for (const file of files) {
+        if (file.name.toLowerCase().endsWith('.mp3')) {
+          window.fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
+        }
+      }
+      audioPlayer.style.display = '';
+      fileLabel.textContent = '\u2705 LPC USB loaded';
+      panelTitle.style.display = 'none';
+      refreshSearch();
+    });
+  }
+
+  document.body.appendChild(fabPanel);
+  document.body.appendChild(fab);
+})();
+</script>

--- a/jekyll/_includes/embed-audio-dir-for-search.html
+++ b/jekyll/_includes/embed-audio-dir-for-search.html
@@ -1,220 +1,35 @@
 
-<style>
-  #audioFab {
-    position: fixed; bottom: 24px; right: 24px; z-index: 1000;
-    height: 48px; min-width: 48px; border-radius: 24px;
-    background: #5a5a9a; border: 2px solid #9a9adf;
-    cursor: pointer; display: flex; flex-direction: row; align-items: center; justify-content: center;
-    gap: 6px; padding: 0 14px; font-size: 22px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
-    transition: background 0.2s, box-shadow 0.2s, min-width 0.2s; line-height: 1;
-  }
-  #audioFabTime {
-    font-size: 13px; font-weight: bold; color: #d0d0ff; letter-spacing: 0.04em;
-    line-height: 1; display: none; white-space: nowrap;
-  }
-  #audioFab:hover { background: #7a7abf; box-shadow: 0 6px 18px rgba(0,0,0,0.6); }
-  #audioFabPanel {
-    position: fixed; bottom: 90px; right: 24px; z-index: 999;
-    background: #1e1e3a; border: 1px solid #7a7abf;
-    border-radius: 14px; padding: 16px 18px;
-    box-shadow: 0 8px 28px rgba(0,0,0,0.6);
-    display: none; flex-direction: column; align-items: center; min-width: 300px; gap: 10px;
-  }
-  #audioFabPanel audio { width: 100%; margin-top: 4px; }
-  #audioFabPanel .fab-panel-title { margin: 0; color: #b0b0e0; font-size: 0.78em; text-align: center; }
-</style>
-
 <script>
-(function () {
-  const isMobile = window.innerWidth <= 768 ||
-    /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent);
-  if (isMobile) return;
-
-  const fab = document.createElement('button');
-  fab.id = 'audioFab';
-  fab.title = 'Listen to track';
-  fab.setAttribute('aria-label', 'Listen to track');
-  fab.textContent = '\uD83C\uDFA7';
-  const fabTimeLabel = document.createElement('span');
-  fabTimeLabel.id = 'audioFabTime';
-  fab.appendChild(fabTimeLabel);
-
-  const fabPanel = document.createElement('div');
-  fabPanel.id = 'audioFabPanel';
-
-  const panelTitle = document.createElement('p');
-  panelTitle.className = 'fab-panel-title';
-  panelTitle.textContent = 'Select the top-level directory for the collection, usually named \u201CLPC USB\u201D';
-  fabPanel.appendChild(panelTitle);
-
-  const audioPlayer = document.createElement('audio');
-  audioPlayer.id = 'audioPlayer';
-  audioPlayer.setAttribute('controls', '');
-  audioPlayer.style.display = 'none';
-  fabPanel.appendChild(audioPlayer);
-
-  document.addEventListener('click', function (e) {
-    const searchResults = document.getElementById('subtitles-search-results');
-    if (!fab.contains(e.target) && !fabPanel.contains(e.target) &&
-        !(searchResults && searchResults.contains(e.target))) {
-      fabPanel.style.display = 'none';
+// Subtitles page: request lpc-player to traverse all files so timestamps work.
+// persistent-player.js handles the FAB, IndexedDB, and window.fileMap.
+(function initSubtitlesAudio() {
+  function tryTraverse() {
+    if (window.lpcPlayer && window.lpcPlayer.isLoaded()) {
+      // Already loaded (e.g. soft-nav from a track page) — nothing to do
+      return;
     }
-  });
+    if (window.lpcPlayer && window.lpcPlayer.handle) {
+      window.lpcPlayer.traverseAll().then(function (ok) {
+        if (ok) document.dispatchEvent(new CustomEvent('lpc-loaded'));
+      });
+    }
+  }
 
-  function refreshSearch() {
-    const searchInput = document.querySelector('#subtitles-search-input');
+  // Run immediately in case persistent-player.js already finished startup
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', tryTraverse);
+  } else {
+    tryTraverse();
+  }
+
+  // Also run when the directory finishes loading (covers the case where
+  // the auto-load in persistent-player.js completes after this script runs)
+  document.addEventListener('lpc-loaded', function () {
+    // Refresh search results so timestamps become links
+    var searchInput = document.querySelector('#subtitles-search-input');
     if (searchInput && searchInput.value.trim() !== '') {
       searchInput.dispatchEvent(new Event('input'));
     }
-  }
-
-  if ('showDirectoryPicker' in window) {
-    // IndexedDB helpers — shared with tracks page (same store)
-    function openDb() {
-      return new Promise(function (resolve, reject) {
-        const req = indexedDB.open('lpc-usb-db', 1);
-        req.onupgradeneeded = function (e) { e.target.result.createObjectStore('handles'); };
-        req.onsuccess = function (e) { resolve(e.target.result); };
-        req.onerror = function () { reject(req.error); };
-      });
-    }
-    async function getStoredHandle() {
-      try {
-        const db = await openDb();
-        return await new Promise(function (resolve) {
-          const tx = db.transaction('handles', 'readonly');
-          const get = tx.objectStore('handles').get('lpcUsb');
-          get.onsuccess = function () { resolve(get.result || null); };
-          get.onerror = function () { resolve(null); };
-        });
-      } catch (e) { return null; }
-    }
-    async function storeHandle(handle) {
-      const db = await openDb();
-      return new Promise(function (resolve, reject) {
-        const tx = db.transaction('handles', 'readwrite');
-        tx.objectStore('handles').put(handle, 'lpcUsb');
-        tx.oncomplete = function () { resolve(); };
-        tx.onerror = function () { reject(tx.error); };
-      });
-    }
-
-    // Recursively traverse the LPC USB dir and build window.fileMap
-    async function traverseDir(dirHandle, path) {
-      for await (const [name, entry] of dirHandle.entries()) {
-        const entryPath = path + '/' + name;
-        if (entry.kind === 'file' && name.toLowerCase().endsWith('.mp3')) {
-          const file = await entry.getFile();
-          window.fileMap[entryPath] = URL.createObjectURL(file);
-        } else if (entry.kind === 'directory') {
-          await traverseDir(entry, entryPath);
-        }
-      }
-    }
-
-    async function loadFromDir(dirHandle) {
-      window.fileMap = {};
-      selectBtn.textContent = '\u23F3 Loading\u2026';
-      selectBtn.disabled = true;
-      await traverseDir(dirHandle, 'LPC USB');
-      audioPlayer.style.display = '';
-      selectBtn.textContent = '\u2705 LPC USB loaded';
-      selectBtn.style.borderColor = 'greenyellow';
-      selectBtn.disabled = false;
-      panelTitle.style.display = 'none';
-      audioPlayer.addEventListener('timeupdate', function () {
-        if (audioPlayer.duration) {
-          const s = Math.floor(audioPlayer.currentTime);
-          fabTimeLabel.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
-          fabTimeLabel.style.display = 'block';
-        }
-      });
-      refreshSearch();
-    }
-
-    let cachedHandle = null;
-    getStoredHandle().then(async function (h) {
-      cachedHandle = h;
-      if (!h) return;
-      try {
-        const perm = await h.queryPermission({ mode: 'read' });
-        if (perm === 'granted') {
-          await loadFromDir(h);
-        }
-      } catch (e) {
-        console.warn('Auto-load on page load failed:', e);
-      }
-    });
-
-    const selectBtn = document.createElement('button');
-    selectBtn.id = 'selectLpcBtn';
-    selectBtn.style.cssText = 'color: greenyellow; background: none; border: 1px solid greenyellow; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-weight: bold;';
-    selectBtn.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
-    fabPanel.insertBefore(selectBtn, audioPlayer);
-
-    selectBtn.addEventListener('click', async function () {
-      try {
-        const dirHandle = await window.showDirectoryPicker({ mode: 'read', startIn: 'music' });
-        await storeHandle(dirHandle);
-        cachedHandle = dirHandle;
-        await loadFromDir(dirHandle);
-      } catch (e) {
-        if (e.name !== 'AbortError') console.error(e);
-      }
-    });
-
-    fab.addEventListener('click', async function () {
-      const isOpen = fabPanel.style.display === 'flex';
-      fabPanel.style.display = isOpen ? 'none' : 'flex';
-      if (!isOpen && audioPlayer.style.display === 'none' && cachedHandle) {
-        try {
-          const perm = await cachedHandle.requestPermission({ mode: 'read' });
-          if (perm === 'granted') {
-            await loadFromDir(cachedHandle);
-          }
-        } catch (e) {
-          console.warn('Could not auto-load from stored handle:', e);
-        }
-      }
-    });
-
-  } else {
-    // Fallback: legacy <input webkitdirectory>
-    const fileLabel = document.createElement('label');
-    fileLabel.setAttribute('for', 'fileInput');
-    fileLabel.style.cssText = 'color: greenyellow; cursor: pointer; font-weight: bold;';
-    fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
-    fabPanel.insertBefore(fileLabel, audioPlayer);
-
-    const fileInput = document.createElement('input');
-    fileInput.type = 'file';
-    fileInput.id = 'fileInput';
-    fileInput.accept = 'audio/mp3';
-    fileInput.setAttribute('webkitdirectory', '');
-    fileInput.multiple = true;
-    fabPanel.insertBefore(fileInput, audioPlayer);
-
-    fab.addEventListener('click', function () {
-      const isOpen = fabPanel.style.display === 'flex';
-      fabPanel.style.display = isOpen ? 'none' : 'flex';
-    });
-
-    fileInput.addEventListener('change', function (event) {
-      window.fileMap = {};
-      const files = event.target.files;
-      for (const file of files) {
-        if (file.name.toLowerCase().endsWith('.mp3')) {
-          window.fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
-        }
-      }
-      audioPlayer.style.display = '';
-      fileLabel.textContent = '\u2705 LPC USB loaded';
-      panelTitle.style.display = 'none';
-      refreshSearch();
-    });
-  }
-
-  document.body.appendChild(fabPanel);
-  document.body.appendChild(fab);
+  });
 })();
 </script>

--- a/jekyll/_includes/embed-audio-dir-for-search.html
+++ b/jekyll/_includes/embed-audio-dir-for-search.html
@@ -2,16 +2,17 @@
 <style>
   #audioFab {
     position: fixed; bottom: 24px; right: 24px; z-index: 1000;
-    width: 56px; height: 56px; border-radius: 50%;
+    height: 48px; min-width: 48px; border-radius: 24px;
     background: #5a5a9a; border: 2px solid #9a9adf;
-    cursor: pointer; display: flex; flex-direction: column; align-items: center; justify-content: center;
-    font-size: 26px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
-    transition: transform 0.2s, background 0.2s, box-shadow 0.2s; line-height: 1; gap: 1px;
+    cursor: pointer; display: flex; flex-direction: row; align-items: center; justify-content: center;
+    gap: 6px; padding: 0 14px; font-size: 22px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+    transition: background 0.2s, box-shadow 0.2s, min-width 0.2s; line-height: 1;
   }
   #audioFabTime {
-    font-size: 8px; color: #d0d0ff; letter-spacing: 0.02em; line-height: 1; display: none;
+    font-size: 13px; font-weight: bold; color: #d0d0ff; letter-spacing: 0.04em;
+    line-height: 1; display: none; white-space: nowrap;
   }
-  #audioFab:hover { background: #7a7abf; transform: scale(1.1); box-shadow: 0 6px 18px rgba(0,0,0,0.6); }
+  #audioFab:hover { background: #7a7abf; box-shadow: 0 6px 18px rgba(0,0,0,0.6); }
   #audioFabPanel {
     position: fixed; bottom: 90px; right: 24px; z-index: 999;
     background: #1e1e3a; border: 1px solid #7a7abf;
@@ -125,7 +126,7 @@
         if (audioPlayer.duration) {
           const s = Math.floor(audioPlayer.currentTime);
           fabTimeLabel.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
-          fabTimeLabel.style.display = '';
+          fabTimeLabel.style.display = 'block';
         }
       });
       refreshSearch();

--- a/jekyll/_includes/footer.html
+++ b/jekyll/_includes/footer.html
@@ -98,5 +98,6 @@ ten is strength
 recalled images are detailed
 -->
 
+<script src="{{ site.baseurl }}/assets/js/persistent-player.js"></script>
 </footer>
 

--- a/jekyll/assets/js/persistent-player.js
+++ b/jekyll/assets/js/persistent-player.js
@@ -45,20 +45,20 @@
   style.textContent = `
     #audioFab {
       position: fixed; bottom: 24px; right: 24px; z-index: 9000;
-      height: 48px; min-width: 48px; border-radius: 24px;
+      height: 60px; min-width: 60px; border-radius: 30px;
       background: #5a5a9a; border: 2px solid #9a9adf;
       cursor: pointer; display: flex; flex-direction: row; align-items: center;
-      justify-content: center; gap: 6px; padding: 0 14px;
-      font-size: 22px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+      justify-content: center; gap: 8px; padding: 0 18px;
+      font-size: 28px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
       transition: background 0.2s, box-shadow 0.2s; line-height: 1;
     }
     #audioFab:hover { background: #7a7abf; box-shadow: 0 6px 18px rgba(0,0,0,0.6); }
     #audioFabTime {
-      font-size: 13px; font-weight: bold; color: #d0d0ff;
+      font-size: 16px; font-weight: bold; color: #d0d0ff;
       letter-spacing: 0.04em; line-height: 1; display: none; white-space: nowrap;
     }
     #audioFabPanel {
-      position: fixed; bottom: 90px; right: 24px; z-index: 8999;
+      position: fixed; bottom: 102px; right: 24px; z-index: 8999;
       background: #1e1e3a; border: 1px solid #7a7abf;
       border-radius: 14px; padding: 16px 18px;
       box-shadow: 0 8px 28px rgba(0,0,0,0.6);

--- a/jekyll/assets/js/persistent-player.js
+++ b/jekyll/assets/js/persistent-player.js
@@ -1,0 +1,341 @@
+// persistent-player.js
+// Manages a site-wide floating audio player FAB that survives page navigation
+// via soft-nav (fetch + history.pushState), so audio keeps playing across pages.
+
+(function () {
+  'use strict';
+
+  const isMobile = window.innerWidth <= 768 ||
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent);
+  if (isMobile) return;
+  if (!('showDirectoryPicker' in window) && !('webkitdirectory' in document.createElement('input'))) return;
+
+  // ── IndexedDB helpers ────────────────────────────────────────────────────────
+  function openDb() {
+    return new Promise(function (resolve, reject) {
+      const req = indexedDB.open('lpc-usb-db', 1);
+      req.onupgradeneeded = function (e) { e.target.result.createObjectStore('handles'); };
+      req.onsuccess = function (e) { resolve(e.target.result); };
+      req.onerror = function () { reject(req.error); };
+    });
+  }
+  async function getStoredHandle() {
+    try {
+      const db = await openDb();
+      return await new Promise(function (resolve) {
+        const tx = db.transaction('handles', 'readonly');
+        const get = tx.objectStore('handles').get('lpcUsb');
+        get.onsuccess = function () { resolve(get.result || null); };
+        get.onerror = function () { resolve(null); };
+      });
+    } catch (e) { return null; }
+  }
+  async function storeHandle(handle) {
+    const db = await openDb();
+    return new Promise(function (resolve, reject) {
+      const tx = db.transaction('handles', 'readwrite');
+      tx.objectStore('handles').put(handle, 'lpcUsb');
+      tx.oncomplete = function () { resolve(); };
+      tx.onerror = function () { reject(tx.error); };
+    });
+  }
+
+  // ── Build FAB DOM ────────────────────────────────────────────────────────────
+  const style = document.createElement('style');
+  style.textContent = `
+    #audioFab {
+      position: fixed; bottom: 24px; right: 24px; z-index: 9000;
+      height: 48px; min-width: 48px; border-radius: 24px;
+      background: #5a5a9a; border: 2px solid #9a9adf;
+      cursor: pointer; display: flex; flex-direction: row; align-items: center;
+      justify-content: center; gap: 6px; padding: 0 14px;
+      font-size: 22px; box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+      transition: background 0.2s, box-shadow 0.2s; line-height: 1;
+    }
+    #audioFab:hover { background: #7a7abf; box-shadow: 0 6px 18px rgba(0,0,0,0.6); }
+    #audioFabTime {
+      font-size: 13px; font-weight: bold; color: #d0d0ff;
+      letter-spacing: 0.04em; line-height: 1; display: none; white-space: nowrap;
+    }
+    #audioFabPanel {
+      position: fixed; bottom: 90px; right: 24px; z-index: 8999;
+      background: #1e1e3a; border: 1px solid #7a7abf;
+      border-radius: 14px; padding: 16px 18px;
+      box-shadow: 0 8px 28px rgba(0,0,0,0.6);
+      display: none; flex-direction: column; align-items: center;
+      min-width: 300px; gap: 10px;
+    }
+    #audioFabPanel audio { width: 100%; margin-top: 4px; }
+    #audioFabPanel .fab-panel-title { margin: 0; color: #b0b0e0; font-size: 0.78em; text-align: center; }
+    #selectLpcBtn {
+      color: greenyellow; background: none; border: 1px solid greenyellow;
+      border-radius: 6px; padding: 6px 12px; cursor: pointer; font-weight: bold;
+    }
+  `;
+  document.head.appendChild(style);
+
+  const fab = document.createElement('button');
+  fab.id = 'audioFab';
+  fab.title = 'Listen to track';
+  fab.setAttribute('aria-label', 'Listen to track');
+  fab.textContent = '🎧';
+
+  const fabTimeLabel = document.createElement('span');
+  fabTimeLabel.id = 'audioFabTime';
+  fab.appendChild(fabTimeLabel);
+
+  const fabPanel = document.createElement('div');
+  fabPanel.id = 'audioFabPanel';
+
+  const panelTitle = document.createElement('p');
+  panelTitle.className = 'fab-panel-title';
+  panelTitle.textContent = 'Select the top-level directory for the collection, usually named \u201CLPC USB\u201D';
+  fabPanel.appendChild(panelTitle);
+
+  const selectBtn = document.createElement('button');
+  selectBtn.id = 'selectLpcBtn';
+  selectBtn.textContent = '⬇️ Select LPC USB ⬇️';
+  fabPanel.appendChild(selectBtn);
+
+  const audioPlayer = document.createElement('audio');
+  audioPlayer.id = 'audioPlayer';
+  audioPlayer.setAttribute('controls', '');
+  audioPlayer.style.display = 'none';
+  fabPanel.appendChild(audioPlayer);
+
+  document.body.appendChild(fabPanel);
+  document.body.appendChild(fab);
+
+  // ── State ────────────────────────────────────────────────────────────────────
+  window.fileMap = window.fileMap || {};   // path → blob URL
+  let cachedHandle = null;
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+  function formatTime(s) {
+    s = Math.floor(s);
+    return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+  }
+
+  function markLoaded() {
+    audioPlayer.style.display = '';
+    selectBtn.textContent = '✅ LPC USB loaded';
+    selectBtn.style.borderColor = 'greenyellow';
+    panelTitle.style.display = 'none';
+  }
+
+  audioPlayer.addEventListener('timeupdate', function () {
+    if (audioPlayer.duration) {
+      fabTimeLabel.textContent = formatTime(audioPlayer.currentTime);
+      fabTimeLabel.style.display = 'block';
+    }
+  });
+
+  // Expose so page scripts can call it
+  window.lpcPlayer = {
+    get handle() { return cachedHandle; },
+    get audio() { return audioPlayer; },
+    get fileMap() { return window.fileMap; },
+    isLoaded: function () { return Object.keys(window.fileMap).length > 0; },
+
+    // Load a specific track from the stored directory handle
+    async loadTrack(albumUsbDir, usbFilename) {
+      if (!cachedHandle) return false;
+      try {
+        const perm = await cachedHandle.queryPermission({ mode: 'read' });
+        let handle = cachedHandle;
+        if (perm !== 'granted') {
+          const granted = await cachedHandle.requestPermission({ mode: 'read' });
+          if (granted !== 'granted') return false;
+        }
+        const albumDir = await handle.getDirectoryHandle(albumUsbDir);
+        const fileHandle = await albumDir.getFileHandle(usbFilename);
+        const file = await fileHandle.getFile();
+        audioPlayer.src = URL.createObjectURL(file);
+        audioPlayer.style.display = '';
+        markLoaded();
+        return true;
+      } catch (e) {
+        console.warn('lpcPlayer.loadTrack failed:', e);
+        return false;
+      }
+    },
+
+    // Traverse entire directory into window.fileMap (for subtitles search)
+    async traverseAll() {
+      if (!cachedHandle) return false;
+      try {
+        const perm = await cachedHandle.queryPermission({ mode: 'read' });
+        if (perm !== 'granted') return false;
+        window.fileMap = {};
+        await traverseDir(cachedHandle, 'LPC USB');
+        audioPlayer.style.display = '';
+        markLoaded();
+        return true;
+      } catch (e) {
+        console.warn('lpcPlayer.traverseAll failed:', e);
+        return false;
+      }
+    }
+  };
+
+  async function traverseDir(dirHandle, path) {
+    for await (const [name, entry] of dirHandle.entries()) {
+      const entryPath = path + '/' + name;
+      if (entry.kind === 'file' && name.toLowerCase().endsWith('.mp3')) {
+        const file = await entry.getFile();
+        window.fileMap[entryPath] = URL.createObjectURL(file);
+      } else if (entry.kind === 'directory') {
+        await traverseDir(entry, entryPath);
+      }
+    }
+  }
+
+  // ── FAB toggle ───────────────────────────────────────────────────────────────
+  fab.addEventListener('click', async function () {
+    const isOpen = fabPanel.style.display === 'flex';
+    fabPanel.style.display = isOpen ? 'none' : 'flex';
+    if (!isOpen && cachedHandle && audioPlayer.style.display === 'none') {
+      try {
+        const perm = await cachedHandle.requestPermission({ mode: 'read' });
+        if (perm === 'granted') {
+          // Let the current page's init handle what to load
+          document.dispatchEvent(new CustomEvent('lpc-permission-granted'));
+        }
+      } catch (e) {
+        console.warn('FAB permission request failed:', e);
+      }
+    }
+  });
+
+  // Close panel on outside click (but not search results)
+  document.addEventListener('click', function (e) {
+    const searchResults = document.getElementById('subtitles-search-results');
+    if (!fab.contains(e.target) && !fabPanel.contains(e.target) &&
+        !(searchResults && searchResults.contains(e.target))) {
+      fabPanel.style.display = 'none';
+    }
+  });
+
+  // ── Select button ────────────────────────────────────────────────────────────
+  selectBtn.addEventListener('click', async function () {
+    if (!('showDirectoryPicker' in window)) return;
+    try {
+      const dirHandle = await window.showDirectoryPicker({ mode: 'read', startIn: 'music' });
+      await storeHandle(dirHandle);
+      cachedHandle = dirHandle;
+      window.fileMap = {};
+      selectBtn.textContent = '⏳ Loading…';
+      selectBtn.disabled = true;
+      await traverseDir(dirHandle, 'LPC USB');
+      selectBtn.disabled = false;
+      markLoaded();
+      document.dispatchEvent(new CustomEvent('lpc-loaded'));
+    } catch (e) {
+      selectBtn.disabled = false;
+      if (e.name !== 'AbortError') console.error(e);
+    }
+  });
+
+  // ── Auto-load on startup ─────────────────────────────────────────────────────
+  getStoredHandle().then(async function (h) {
+    cachedHandle = h;
+    if (!h) return;
+    try {
+      const perm = await h.queryPermission({ mode: 'read' });
+      if (perm === 'granted') {
+        await traverseDir(h, 'LPC USB');
+        markLoaded();
+        document.dispatchEvent(new CustomEvent('lpc-loaded'));
+      }
+    } catch (e) {
+      console.warn('Auto-load on startup failed:', e);
+    }
+  });
+
+  // ── Soft navigation ──────────────────────────────────────────────────────────
+  // Intercept same-origin link clicks and swap only <main> content.
+  // The FAB and audio element stay alive so playback continues.
+
+  const MAIN_SEL = 'main.page-content';
+
+  // Persistent record of external script URLs that have been executed at least once.
+  // DOM queries alone can't catch scripts removed by previous innerHTML swaps, so we
+  // track them here in the closure across all soft-navigations.
+  const _executedScriptSrcs = new Set(
+    Array.from(document.querySelectorAll('script[src]')).map(function (s) {
+      return new URL(s.src, location.href).href;
+    })
+  );
+
+  function isSameOriginLink(a) {
+    return a.hostname === location.hostname &&
+           !a.hasAttribute('target') &&
+           !a.hasAttribute('download') &&
+           (a.protocol === 'http:' || a.protocol === 'https:');
+  }
+
+  async function softNavigate(url) {
+    try {
+      const res = await fetch(url, { credentials: 'same-origin' });
+      if (!res.ok) { location.href = url; return; }
+      const html = await res.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+
+      const newMain = doc.querySelector(MAIN_SEL);
+      const oldMain = document.querySelector(MAIN_SEL);
+      if (!newMain || !oldMain) { location.href = url; return; }
+
+      // Swap title
+      document.title = doc.title;
+
+      // Swap main content
+      oldMain.innerHTML = newMain.innerHTML;
+
+      // Update URL
+      history.pushState({ url }, doc.title, url);
+
+      // Re-run script tags in the new content.
+      // Use the persistent _executedScriptSrcs set so scripts removed from the DOM
+      // by previous innerHTML swaps are still recognised as already executed.
+      oldMain.querySelectorAll('script').forEach(function (orig) {
+        if (orig.src) {
+          const abs = new URL(orig.src, location.href).href;
+          if (_executedScriptSrcs.has(abs)) return; // already ran — skip
+          _executedScriptSrcs.add(abs);             // mark as executed
+        }
+        const s = document.createElement('script');
+        Array.from(orig.attributes).forEach(function (a) { s.setAttribute(a.name, a.value); });
+        if (!orig.src) s.textContent = orig.textContent;
+        orig.parentNode.replaceChild(s, orig);
+      });
+
+      // Scroll to top
+      window.scrollTo(0, 0);
+
+      // Notify page scripts that the page changed
+      document.dispatchEvent(new CustomEvent('soft-nav', { detail: { url } }));
+    } catch (e) {
+      console.warn('Soft nav failed, doing hard nav:', e);
+      location.href = url;
+    }
+  }
+
+  document.addEventListener('click', function (e) {
+    const a = e.target.closest('a');
+    if (!a || !isSameOriginLink(a)) return;
+    const url = a.href;
+    // Skip anchor-only links
+    try {
+      const u = new URL(url);
+      if (u.pathname === location.pathname && u.hash) return;
+    } catch (_) { return; }
+    e.preventDefault();
+    softNavigate(url);
+  });
+
+  window.addEventListener('popstate', function (e) {
+    softNavigate(location.href);
+  });
+
+})();

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -386,52 +386,34 @@ async function main(callback) {
         
         // Function to programmatically run the speakers search for "Alex Trebek"
         function runSpeakerSearchForAlexTrebek() {
-            let resultsContainer = document.querySelector('#alex-tracks-span');
-            if (!resultsContainer) {
-                // Only run on the Alex Trebek page
-                return;
-            }
-            let speakersSearchInput = document.querySelector('#speakers-search-input');
-            if (!speakersSearchInput) {
-                // Create a hidden input if it doesn't exist
-                speakersSearchInput = document.createElement('input');
-                speakersSearchInput.type = 'hidden';
-                speakersSearchInput.id = 'speakers-search-input';
-                document.body.appendChild(speakersSearchInput);
-                // Attach the event listener as in main()
-                speakersSearchInput.addEventListener('input', function () {
-                    if (this.value.trim() !== "") {
-                        const query = this.value.trim().split(' ').map(word => `+${word}`).join(' ');
-                        const results = idxSpeaker.search(query);
-                        resultsContainer.innerHTML = '';
-                        let tracksWithSpeaker = new Set();
-                        results.forEach(function (result) {
-                            const matchedDoc = dataStructure.find(doc => doc.id === result.ref);
-                            const key = createKey(matchedDoc.Album, matchedDoc.Track_Title, matchedDoc.Speaker);
-                            if (!tracksWithSpeaker.has(key)) {
-                                tracksWithSpeaker.add(key);
-                                const albumAndTitleItem = document.createElement('li');
-                                albumAndTitleItem.innerHTML = `
-                                    <i><a href="${BASE_URL}/tracks/?album=${matchedDoc.Album_Slug}&track=${matchedDoc.Track_Slug}">${matchedDoc.Track_Title}</a></i> --
-                                    ${matchedDoc.Album} <img src="${BASE_URL}/assets/img/albums/${matchedDoc.Album_Picture}" alt="${matchedDoc.Album}" width="15" height="15">
-                                `;
-                                resultsContainer.appendChild(albumAndTitleItem);
-                            }
-                        });
-                    }
-                });
-            }
-            speakersSearchInput.value = 'Alex Trebek';
-            speakersSearchInput.dispatchEvent(new Event('input'));
+            const resultsContainer = document.querySelector('#alex-tracks-span');
+            if (!resultsContainer) return; // Only run on the Alex Trebek page
+
+            const results = idxSpeaker.search('+Alex +Trebek');
+            resultsContainer.innerHTML = '';
+            let tracksWithSpeaker = new Set();
+            results.forEach(function (result) {
+                const matchedDoc = dataStructure.find(doc => doc.id === result.ref);
+                const key = createKey(matchedDoc.Album, matchedDoc.Track_Title, matchedDoc.Speaker);
+                if (!tracksWithSpeaker.has(key)) {
+                    tracksWithSpeaker.add(key);
+                    const albumAndTitleItem = document.createElement('li');
+                    albumAndTitleItem.innerHTML = `
+                        <i><a href="${BASE_URL}/tracks/?album=${matchedDoc.Album_Slug}&track=${matchedDoc.Track_Slug}">${matchedDoc.Track_Title}</a></i> --
+                        ${matchedDoc.Album} <img src="${BASE_URL}/assets/img/albums/${matchedDoc.Album_Picture}" alt="${matchedDoc.Album}" width="15" height="15">
+                    `;
+                    resultsContainer.appendChild(albumAndTitleItem);
+                }
+            });
         }
 
-        // Set up the subtitles search input listener
-        if (document.querySelector('#subtitles-search-input')) {
-            // fileMap is populated by the LPC USB FAB (embed-audio-dir-for-search.html)
-            window.fileMap = window.fileMap || {};
-            document.querySelector('#subtitles-search-input').addEventListener('input', function () {
-                if (this.value.trim() != "") {
-                    const query = this.value.trim().split(' ').map(word => `+${word}`).join(' '); // Add + to each word for logical AND searching
+        // Set up the subtitles search input listener (delegated so it survives soft-nav DOM swaps)
+        window.fileMap = window.fileMap || {};
+        document.addEventListener('input', function (e) {
+            if (!e.target.matches('#subtitles-search-input')) return;
+            (function (input) {
+                if (input.value.trim() != "") {
+                    const query = input.value.trim().split(' ').map(word => `+${word}`).join(' '); // Add + to each word for logical AND searching
                     const results = idxText.search(query);
                     //console.log("Search query:", query);
                     //console.log("Search results:", results);
@@ -509,14 +491,15 @@ async function main(callback) {
                     totalCountContainer.innerHTML = `Subtitles found: ${resultCount}`;
                     resultList.insertBefore(totalCountContainer, resultList.firstChild);
                 }
-            });
-        }
+            })(e.target);
+        });
 
-        // Set up the speakers search input listener
-        if (document.querySelector('#speakers-search-input')) {
-            document.querySelector('#speakers-search-input').addEventListener('input', function () {
-                if (this.value.trim() !== "") {
-                    const query = this.value.trim().split(' ').map(word => `+${word}`).join(' '); // Add + to each word for logical AND searching
+        // Set up the speakers search input listener (delegated)
+        document.addEventListener('input', function (e) {
+            if (!e.target.matches('#speakers-search-input')) return;
+            (function (input) {
+                if (input.value.trim() !== "") {
+                    const query = input.value.trim().split(' ').map(word => `+${word}`).join(' '); // Add + to each word for logical AND searching
                     const results = idxSpeaker.search(query);
                     //console.log("Search query:", query);
                     //console.log("Search results:", results);
@@ -557,13 +540,14 @@ async function main(callback) {
                     totalCountContainer.innerHTML = `<br/><p>Unique track-speaker combinations: ${trackCount}</p>`;
                     resultList.insertBefore(totalCountContainer, resultList.firstChild);
                 }
-            });
-        }
+            })(e.target);
+        });
 
-        // Set up the aliases search input listener
-        if (document.querySelector('#aliases-search-input')) {
-            document.querySelector('#aliases-search-input').addEventListener('input', function () {
-                const query = this.value.trim().toLowerCase();
+        // Set up the aliases search input listener (delegated)
+        document.addEventListener('input', function (e) {
+            if (!e.target.matches('#aliases-search-input')) return;
+            (function (input) {
+                const query = input.value.trim().toLowerCase();
                 const resultList = document.querySelector('#aliases-search-results');
                 resultList.innerHTML = '';
                 if (query === "") return;
@@ -593,13 +577,14 @@ async function main(callback) {
                 totalCountContainer.style.marginBottom = '25px';
                 totalCountContainer.innerHTML = `<br/><p>Unique track-alias combinations: ${matchCount}</p>`;
                 resultList.insertBefore(totalCountContainer, resultList.firstChild);
-            });
-        }
+            })(e.target);
+        });
 
-        // Set up the establishments search input listener
-        if (document.querySelector('#establishments-search-input')) {
-            document.querySelector('#establishments-search-input').addEventListener('input', function () {
-                const query = this.value.trim().toLowerCase();
+        // Set up the establishments search input listener (delegated)
+        document.addEventListener('input', function (e) {
+            if (!e.target.matches('#establishments-search-input')) return;
+            (function (input) {
+                const query = input.value.trim().toLowerCase();
                 const resultList = document.querySelector('#establishments-search-results');
                 resultList.innerHTML = '';
                 if (query === "") return;
@@ -628,8 +613,8 @@ async function main(callback) {
                 totalCountContainer.style.marginBottom = '25px';
                 totalCountContainer.innerHTML = `<br/><p>Unique track-establishment combinations: ${matchCount}</p>`;
                 resultList.insertBefore(totalCountContainer, resultList.firstChild);
-            });
-        }
+            })(e.target);
+        });
 
         function onDomContentLoaded() {
             const countOfAlexTrebek = getNumberOfTracksThatAlexTrebekIsIn();
@@ -654,6 +639,9 @@ async function main(callback) {
         function createKey(albumTitle, trackTitle, speaker) {
             return `${albumTitle}-${trackTitle}-${speaker}`;
         }
+
+        // Expose so the module-level soft-nav listener can call it after async work is done
+        window._wtOnDomContentLoaded = onDomContentLoaded;
 
         callback(true);
 
@@ -681,4 +669,13 @@ main(function(dataReady) {
                     .forEach(input => input && (input.disabled = false));
                 handleSearchParameter();
         }
+});
+
+// Re-run page-specific UI after soft-nav swaps the DOM.
+// Registered here at module level (not inside async main()) so it is always
+// active regardless of how long main() takes to finish.
+document.addEventListener('soft-nav', function () {
+    if (typeof window._wtOnDomContentLoaded === 'function') {
+        window._wtOnDomContentLoaded();
+    }
 });

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -427,29 +427,8 @@ async function main(callback) {
 
         // Set up the subtitles search input listener
         if (document.querySelector('#subtitles-search-input')) {
-            fileMap = {};
-            if(jekyll_env != "production") {
-                const fileInput = document.getElementById('fileInput');
-                const audio = document.getElementById('audioPlayer');
-                fileInput.addEventListener('change', function(event) {
-                    fileTarget = event.target;
-                    const files = fileTarget.files;
-                    for (const file of files) {
-                        if (file.name.endsWith('.mp3')) {
-                            const url = URL.createObjectURL(file);
-                            fileMap[file.webkitRelativePath] = url;
-                        }  
-                    }
-                    console.log("Files have been uploaded! Jumping to a subtitle will now work!");
-
-                    // Update the input of #subtitles-search-input
-                    const subtitlesSearchInput = document.querySelector('#subtitles-search-input');
-                    if (subtitlesSearchInput) {
-                        subtitlesSearchInput.value = subtitlesSearchInput.value; // Set the value to itself
-                        subtitlesSearchInput.dispatchEvent(new Event('input')); // Trigger the input event
-                    }
-                });
-            }
+            // fileMap is populated by the LPC USB FAB (embed-audio-dir-for-search.html)
+            window.fileMap = window.fileMap || {};
             document.querySelector('#subtitles-search-input').addEventListener('input', function () {
                 if (this.value.trim() != "") {
                     const query = this.value.trim().split(' ').map(word => `+${word}`).join(' '); // Add + to each word for logical AND searching
@@ -475,7 +454,7 @@ async function main(callback) {
                             <i><a href="${BASE_URL}/tracks/?album=${matchedDoc.Album_Slug}&track=${matchedDoc.Track_Slug}">${matchedDoc.Track_Title}</a></i>
                         `;
 
-                        if (!fileMap || Object.keys(fileMap).length === 0) {
+                        if (!window.fileMap || Object.keys(window.fileMap).length === 0) {
                             albumAndTitleItem.innerHTML += `
                                 <small> @ ${matchedDoc.StartTime}</small>
                             `;
@@ -502,7 +481,7 @@ async function main(callback) {
                             startTimeLink.addEventListener('click', function(e) {
                                 const relevantUrl = `LPC USB/${matchedAlbumYear} - ${matchedAlbumTitle}/${trackTitleDetail}.mp3`;
                                 // console.log('Relevant URL: ' + relevantUrl);
-                                const matchingUrl = fileMap[relevantUrl];
+                                const matchingUrl = window.fileMap[relevantUrl];
                                 // console.log('Matching URL: ' + matchingUrl);
                                 e.preventDefault();
                                 const audioPlayer = document.getElementById('audioPlayer');

--- a/jekyll/assets/js/search.js
+++ b/jekyll/assets/js/search.js
@@ -616,15 +616,21 @@ async function main(callback) {
             })(e.target);
         });
 
+        // Cache the Alex Trebek count so the lunr search only runs once ever.
+        let _cachedAlexCount = null;
+
         function onDomContentLoaded() {
-            const countOfAlexTrebek = getNumberOfTracksThatAlexTrebekIsIn();
+            // Only do Alex-related work when on the Alex Trebek page.
             const alexCountSpan = document.querySelector('#alex-count-span');
+            const alexTracksSpan = document.querySelector('#alex-tracks-span');
+            if (!alexCountSpan && !alexTracksSpan) return;
+
             if (alexCountSpan) {
-                alexCountSpan.textContent = countOfAlexTrebek;
-            } else {
-                // console.error('Element with id "alex-count-span" not found.');
+                if (_cachedAlexCount === null) {
+                    _cachedAlexCount = getNumberOfTracksThatAlexTrebekIsIn();
+                }
+                alexCountSpan.textContent = _cachedAlexCount;
             }
-            // Display the results for Alex Trebek
             runSpeakerSearchForAlexTrebek();
         }
         
@@ -676,6 +682,6 @@ main(function(dataReady) {
 // active regardless of how long main() takes to finish.
 document.addEventListener('soft-nav', function () {
     if (typeof window._wtOnDomContentLoaded === 'function') {
-        window._wtOnDomContentLoaded();
+        setTimeout(window._wtOnDomContentLoaded, 0);
     }
 });

--- a/jekyll/tracks/index.html
+++ b/jekyll/tracks/index.html
@@ -55,12 +55,21 @@ hide_from_nav: true
     border: 2px solid #9a9adf;
     cursor: pointer;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     font-size: 26px;
     box-shadow: 0 4px 14px rgba(0,0,0,0.5);
     transition: transform 0.2s, background 0.2s, box-shadow 0.2s;
     line-height: 1;
+    gap: 1px;
+  }
+  #audioFabTime {
+    font-size: 8px;
+    color: #d0d0ff;
+    letter-spacing: 0.02em;
+    line-height: 1;
+    display: none;
   }
   #audioFab:hover {
     background: #7a7abf;
@@ -261,6 +270,8 @@ hide_from_nav: true
   if (!isMobile) {
     const fab = el('button', { id: 'audioFab', title: 'Listen to track', 'aria-label': 'Listen to track' });
     fab.textContent = '\uD83C\uDFA7';
+    const fabTimeLabel = el('span', { id: 'audioFabTime' });
+    fab.appendChild(fabTimeLabel);
 
     const fabPanel = el('div', { id: 'audioFabPanel' });
 
@@ -325,6 +336,13 @@ hide_from_nav: true
           selectBtn.textContent = '\u2705 LPC USB loaded';
           selectBtn.style.borderColor = 'greenyellow';
           panelTitle.style.display = 'none';
+          audioPlayer.addEventListener('timeupdate', function () {
+            if (audioPlayer.duration) {
+              const s = Math.floor(audioPlayer.currentTime);
+              fabTimeLabel.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+              fabTimeLabel.style.display = '';
+            }
+          });
         } catch (e) {
           console.warn('Could not load track from directory:', e);
         }

--- a/jekyll/tracks/index.html
+++ b/jekyll/tracks/index.html
@@ -268,24 +268,9 @@ hide_from_nav: true
     panelTitle.textContent = 'Select the top-level directory for the collection, usually named \u201CLPC USB\u201D';
     fabPanel.appendChild(panelTitle);
 
-    const fileLabel = el('label', { for: 'fileInput', class: 'tooltip', style: 'color: greenyellow; cursor: pointer; font-weight: bold;' });
-    fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
-    const tooltipSpan = el('span', { class: 'tooltiptext' });
-    tooltipSpan.textContent = 'Select the top-level directory for the collection, usually named "LPC USB"';
-    fileLabel.appendChild(tooltipSpan);
-    fabPanel.appendChild(fileLabel);
-
-    const fileInput = el('input', { type: 'file', id: 'fileInput', accept: 'audio/mp3', webkitdirectory: '', multiple: '' });
-    fabPanel.appendChild(fileInput);
-
     const audioPlayer = el('audio', { id: 'audioPlayer', controls: '' });
     audioPlayer.style.display = 'none';
     fabPanel.appendChild(audioPlayer);
-
-    fab.addEventListener('click', function () {
-      const isOpen = fabPanel.style.display === 'flex';
-      fabPanel.style.display = isOpen ? 'none' : 'flex';
-    });
 
     // Close panel when clicking outside
     document.addEventListener('click', function (e) {
@@ -294,25 +279,126 @@ hide_from_nav: true
       }
     });
 
-    // File selection handler
-    const fileMap = {};
-    fileInput.addEventListener('change', function (event) {
-      const files = event.target.files;
-      for (const file of files) {
-        fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
+    if ('showDirectoryPicker' in window) {
+      // --- File System Access API: persists handle across page navigations via IndexedDB ---
+      function openDb() {
+        return new Promise(function (resolve, reject) {
+          const req = indexedDB.open('lpc-usb-db', 1);
+          req.onupgradeneeded = function (e) { e.target.result.createObjectStore('handles'); };
+          req.onsuccess = function (e) { resolve(e.target.result); };
+          req.onerror = function () { reject(req.error); };
+        });
       }
-      const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
-      const relevantUrl = 'LPC USB/' + album.USB_Directory + '/' + usbFilename;
-      console.log('Relevant URL: ' + relevantUrl);
-      const matchingUrl = fileMap[relevantUrl];
-      console.log('Matching URL: ' + matchingUrl);
-      if (matchingUrl) {
-        audioPlayer.src = matchingUrl;
-        audioPlayer.style.display = '';
-      } else {
-        console.warn('Audio file not found in selected directory: ' + relevantUrl);
+      async function getStoredHandle() {
+        try {
+          const db = await openDb();
+          return await new Promise(function (resolve) {
+            const tx = db.transaction('handles', 'readonly');
+            const get = tx.objectStore('handles').get('lpcUsb');
+            get.onsuccess = function () { resolve(get.result || null); };
+            get.onerror = function () { resolve(null); };
+          });
+        } catch (e) { return null; }
       }
-    });
+      async function storeHandle(handle) {
+        const db = await openDb();
+        return new Promise(function (resolve, reject) {
+          const tx = db.transaction('handles', 'readwrite');
+          tx.objectStore('handles').put(handle, 'lpcUsb');
+          tx.oncomplete = function () { resolve(); };
+          tx.onerror = function () { reject(tx.error); };
+        });
+      }
+
+      // Pre-load handle into memory so FAB click can use it without any prior awaits
+      let cachedHandle = null;
+      getStoredHandle().then(function (h) { cachedHandle = h; });
+
+      async function loadTrackFromDir(dirHandle) {
+        try {
+          const albumDir = await dirHandle.getDirectoryHandle(album.USB_Directory);
+          const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
+          const fileHandle = await albumDir.getFileHandle(usbFilename);
+          const file = await fileHandle.getFile();
+          audioPlayer.src = URL.createObjectURL(file);
+          audioPlayer.style.display = '';
+          selectBtn.textContent = '\u2705 LPC USB loaded';
+          selectBtn.style.borderColor = 'greenyellow';
+          panelTitle.style.display = 'none';
+        } catch (e) {
+          console.warn('Could not load track from directory:', e);
+        }
+      }
+
+      const selectBtn = el('button', { id: 'selectLpcBtn', style: 'color: greenyellow; background: none; border: 1px solid greenyellow; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-weight: bold;' });
+      selectBtn.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
+      fabPanel.insertBefore(selectBtn, audioPlayer);
+
+      selectBtn.addEventListener('click', async function () {
+        try {
+          const dirHandle = await window.showDirectoryPicker({ mode: 'read', startIn: 'music' });
+          await storeHandle(dirHandle);
+          cachedHandle = dirHandle;
+          await loadTrackFromDir(dirHandle);
+        } catch (e) {
+          if (e.name !== 'AbortError') console.error(e);
+        }
+      });
+
+      // FAB click is a user gesture. With cachedHandle already in memory (no await needed),
+      // requestPermission fires immediately within the activation window — this is what
+      // allows the browser to re-grant permission across page navigations without re-picking.
+      fab.addEventListener('click', async function () {
+        const isOpen = fabPanel.style.display === 'flex';
+        fabPanel.style.display = isOpen ? 'none' : 'flex';
+        if (!isOpen && audioPlayer.style.display === 'none' && cachedHandle) {
+          try {
+            const perm = await cachedHandle.requestPermission({ mode: 'read' });
+            if (perm === 'granted') {
+              await loadTrackFromDir(cachedHandle);
+            }
+          } catch (e) {
+            console.warn('Could not auto-load from stored handle:', e);
+          }
+        }
+      });
+
+    } else {
+      // --- Fallback: legacy <input webkitdirectory> for browsers without File System Access API ---
+      const fileLabel = el('label', { for: 'fileInput', class: 'tooltip', style: 'color: greenyellow; cursor: pointer; font-weight: bold;' });
+      fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
+      const tooltipSpan = el('span', { class: 'tooltiptext' });
+      tooltipSpan.textContent = 'Select the top-level directory for the collection, usually named "LPC USB"';
+      fileLabel.appendChild(tooltipSpan);
+      fabPanel.insertBefore(fileLabel, audioPlayer);
+
+      const fileInput = el('input', { type: 'file', id: 'fileInput', accept: 'audio/mp3', webkitdirectory: '', multiple: '' });
+      fabPanel.insertBefore(fileInput, audioPlayer);
+
+      fab.addEventListener('click', function () {
+        const isOpen = fabPanel.style.display === 'flex';
+        fabPanel.style.display = isOpen ? 'none' : 'flex';
+      });
+
+      const fileMap = {};
+      fileInput.addEventListener('change', function (event) {
+        const files = event.target.files;
+        for (const file of files) {
+          fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
+        }
+        const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
+        const relevantUrl = 'LPC USB/' + album.USB_Directory + '/' + usbFilename;
+        console.log('Relevant URL: ' + relevantUrl);
+        const matchingUrl = fileMap[relevantUrl];
+        console.log('Matching URL: ' + matchingUrl);
+        if (matchingUrl) {
+          audioPlayer.src = matchingUrl;
+          audioPlayer.style.display = '';
+        } else {
+          console.warn('Audio file not found in selected directory: ' + relevantUrl);
+        }
+      });
+    }
 
     document.body.appendChild(fabPanel);
     document.body.appendChild(fab);

--- a/jekyll/tracks/index.html
+++ b/jekyll/tracks/index.html
@@ -42,68 +42,6 @@ hide_from_nav: true
     visibility: visible;
     opacity: 1;
   }
-
-  #audioFab {
-    position: fixed;
-    bottom: 24px;
-    right: 24px;
-    z-index: 1000;
-    height: 48px;
-    min-width: 48px;
-    border-radius: 24px;
-    background: #5a5a9a;
-    border: 2px solid #9a9adf;
-    cursor: pointer;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    padding: 0 14px;
-    font-size: 22px;
-    box-shadow: 0 4px 14px rgba(0,0,0,0.5);
-    transition: background 0.2s, box-shadow 0.2s, min-width 0.2s;
-    line-height: 1;
-  }
-  #audioFab:hover {
-    background: #7a7abf;
-    box-shadow: 0 6px 18px rgba(0,0,0,0.6);
-  }
-  #audioFabTime {
-    font-size: 13px;
-    font-weight: bold;
-    color: #d0d0ff;
-    letter-spacing: 0.04em;
-    line-height: 1;
-    display: none;
-    white-space: nowrap;
-  }
-  #audioFabPanel {
-    position: fixed;
-    bottom: 90px;
-    right: 24px;
-    z-index: 999;
-    background: #1e1e3a;
-    border: 1px solid #7a7abf;
-    border-radius: 14px;
-    padding: 16px 18px;
-    box-shadow: 0 8px 28px rgba(0,0,0,0.6);
-    display: none;
-    flex-direction: column;
-    align-items: center;
-    min-width: 300px;
-    gap: 10px;
-  }
-  #audioFabPanel audio {
-    width: 100%;
-    margin-top: 4px;
-  }
-  #audioFabPanel .fab-panel-title {
-    margin: 0;
-    color: #b0b0e0;
-    font-size: 0.78em;
-    text-align: center;
-  }
 </style>
 
 <script>
@@ -265,164 +203,52 @@ hide_from_nav: true
       'Deliveries: ' + track.Deliveries.join(', ')));
   }
 
-  // ---- Audio player (floating FAB) ----
-  const isMobile = window.innerWidth <= 768 ||
-    /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent);
+  // ---- Audio player (delegates to persistent-player.js) ----
+  // Container in the page for a "Play this track" button when audio is already playing
+  const audioContainer = el('div', { style: 'text-align: center; margin: 10px 0;' });
+  frag.appendChild(audioContainer);
 
-  if (!isMobile) {
-    const fab = el('button', { id: 'audioFab', title: 'Listen to track', 'aria-label': 'Listen to track' });
-    fab.textContent = '\uD83C\uDFA7';
-    const fabTimeLabel = el('span', { id: 'audioFabTime' });
-    fab.appendChild(fabTimeLabel);
-
-    const fabPanel = el('div', { id: 'audioFabPanel' });
-
-    const panelTitle = el('p', { class: 'fab-panel-title' });
-    panelTitle.textContent = 'Select the top-level directory for the collection, usually named \u201CLPC USB\u201D';
-    fabPanel.appendChild(panelTitle);
-
-    const audioPlayer = el('audio', { id: 'audioPlayer', controls: '' });
-    audioPlayer.style.display = 'none';
-    fabPanel.appendChild(audioPlayer);
-
-    // Close panel when clicking outside
-    document.addEventListener('click', function (e) {
-      if (!fab.contains(e.target) && !fabPanel.contains(e.target)) {
-        fabPanel.style.display = 'none';
-      }
-    });
-
-    if ('showDirectoryPicker' in window) {
-      // --- File System Access API: persists handle across page navigations via IndexedDB ---
-      function openDb() {
-        return new Promise(function (resolve, reject) {
-          const req = indexedDB.open('lpc-usb-db', 1);
-          req.onupgradeneeded = function (e) { e.target.result.createObjectStore('handles'); };
-          req.onsuccess = function (e) { resolve(e.target.result); };
-          req.onerror = function () { reject(req.error); };
-        });
-      }
-      async function getStoredHandle() {
-        try {
-          const db = await openDb();
-          return await new Promise(function (resolve) {
-            const tx = db.transaction('handles', 'readonly');
-            const get = tx.objectStore('handles').get('lpcUsb');
-            get.onsuccess = function () { resolve(get.result || null); };
-            get.onerror = function () { resolve(null); };
-          });
-        } catch (e) { return null; }
-      }
-      async function storeHandle(handle) {
-        const db = await openDb();
-        return new Promise(function (resolve, reject) {
-          const tx = db.transaction('handles', 'readwrite');
-          tx.objectStore('handles').put(handle, 'lpcUsb');
-          tx.oncomplete = function () { resolve(); };
-          tx.onerror = function () { reject(tx.error); };
-        });
-      }
-
-      // Pre-load handle into memory so FAB click can use it without any prior awaits
-      let cachedHandle = null;
-      getStoredHandle().then(function (h) { cachedHandle = h; });
-
-      async function loadTrackFromDir(dirHandle) {
-        try {
-          const albumDir = await dirHandle.getDirectoryHandle(album.USB_Directory);
-          const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
-          const fileHandle = await albumDir.getFileHandle(usbFilename);
-          const file = await fileHandle.getFile();
-          audioPlayer.src = URL.createObjectURL(file);
-          audioPlayer.style.display = '';
-          selectBtn.textContent = '\u2705 LPC USB loaded';
-          selectBtn.style.borderColor = 'greenyellow';
-          panelTitle.style.display = 'none';
-          audioPlayer.addEventListener('timeupdate', function () {
-            if (audioPlayer.duration) {
-              const s = Math.floor(audioPlayer.currentTime);
-              fabTimeLabel.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
-              fabTimeLabel.style.display = 'block';
-            }
-          });
-        } catch (e) {
-          console.warn('Could not load track from directory:', e);
-        }
-      }
-
-      const selectBtn = el('button', { id: 'selectLpcBtn', style: 'color: greenyellow; background: none; border: 1px solid greenyellow; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-weight: bold;' });
-      selectBtn.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
-      fabPanel.insertBefore(selectBtn, audioPlayer);
-
-      selectBtn.addEventListener('click', async function () {
-        try {
-          const dirHandle = await window.showDirectoryPicker({ mode: 'read', startIn: 'music' });
-          await storeHandle(dirHandle);
-          cachedHandle = dirHandle;
-          await loadTrackFromDir(dirHandle);
-        } catch (e) {
-          if (e.name !== 'AbortError') console.error(e);
-        }
+  function applyTrackAudio(matchingUrl) {
+    const audio = window.lpcPlayer.audio;
+    if (!audio.paused) {
+      // Something is actively playing — don't interrupt; offer a button to switch
+      audioContainer.innerHTML = '';
+      const btn = document.createElement('button');
+      btn.textContent = '\u25B6 Play this track';
+      btn.style.cssText = 'color: greenyellow; background: none; border: 1px solid greenyellow; border-radius: 6px; padding: 6px 14px; cursor: pointer; font-weight: bold; font-size: 1em;';
+      btn.addEventListener('click', function () {
+        audio.src = matchingUrl;
+        audio.style.display = '';
+        audio.play();
+        btn.remove();
       });
-
-      // FAB click is a user gesture. With cachedHandle already in memory (no await needed),
-      // requestPermission fires immediately within the activation window — this is what
-      // allows the browser to re-grant permission across page navigations without re-picking.
-      fab.addEventListener('click', async function () {
-        const isOpen = fabPanel.style.display === 'flex';
-        fabPanel.style.display = isOpen ? 'none' : 'flex';
-        if (!isOpen && audioPlayer.style.display === 'none' && cachedHandle) {
-          try {
-            const perm = await cachedHandle.requestPermission({ mode: 'read' });
-            if (perm === 'granted') {
-              await loadTrackFromDir(cachedHandle);
-            }
-          } catch (e) {
-            console.warn('Could not auto-load from stored handle:', e);
-          }
-        }
-      });
-
+      audioContainer.appendChild(btn);
     } else {
-      // --- Fallback: legacy <input webkitdirectory> for browsers without File System Access API ---
-      const fileLabel = el('label', { for: 'fileInput', class: 'tooltip', style: 'color: greenyellow; cursor: pointer; font-weight: bold;' });
-      fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
-      const tooltipSpan = el('span', { class: 'tooltiptext' });
-      tooltipSpan.textContent = 'Select the top-level directory for the collection, usually named "LPC USB"';
-      fileLabel.appendChild(tooltipSpan);
-      fabPanel.insertBefore(fileLabel, audioPlayer);
-
-      const fileInput = el('input', { type: 'file', id: 'fileInput', accept: 'audio/mp3', webkitdirectory: '', multiple: '' });
-      fabPanel.insertBefore(fileInput, audioPlayer);
-
-      fab.addEventListener('click', function () {
-        const isOpen = fabPanel.style.display === 'flex';
-        fabPanel.style.display = isOpen ? 'none' : 'flex';
-      });
-
-      const fileMap = {};
-      fileInput.addEventListener('change', function (event) {
-        const files = event.target.files;
-        for (const file of files) {
-          fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
-        }
-        const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
-        const relevantUrl = 'LPC USB/' + album.USB_Directory + '/' + usbFilename;
-        console.log('Relevant URL: ' + relevantUrl);
-        const matchingUrl = fileMap[relevantUrl];
-        console.log('Matching URL: ' + matchingUrl);
-        if (matchingUrl) {
-          audioPlayer.src = matchingUrl;
-          audioPlayer.style.display = '';
-        } else {
-          console.warn('Audio file not found in selected directory: ' + relevantUrl);
-        }
-      });
+      // Nothing playing — auto-load this track
+      audio.src = matchingUrl;
+      audio.style.display = '';
     }
-
-    document.body.appendChild(fabPanel);
-    document.body.appendChild(fab);
   }
+
+  function initTrackAudio() {
+    const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
+    const albumUsbDir = album.USB_Directory;
+    const relevantUrl = 'LPC USB/' + albumUsbDir + '/' + usbFilename;
+
+    if (window.lpcPlayer && window.lpcPlayer.isLoaded()) {
+      const matchingUrl = window.fileMap[relevantUrl];
+      if (matchingUrl) applyTrackAudio(matchingUrl);
+    }
+    // Load when directory is selected/granted for the first time
+    document.addEventListener('lpc-loaded', function () {
+      const matchingUrl = window.fileMap[relevantUrl];
+      if (matchingUrl) applyTrackAudio(matchingUrl);
+    }, { once: true });
+    document.addEventListener('lpc-permission-granted', async function () {
+      await window.lpcPlayer.loadTrack(albumUsbDir, usbFilename);
+    }, { once: true });
+  }
+  initTrackAudio();
 
   // ---- Subtitles ----
   frag.appendChild(hr());

--- a/jekyll/tracks/index.html
+++ b/jekyll/tracks/index.html
@@ -279,6 +279,7 @@ hide_from_nav: true
     fabPanel.appendChild(fileInput);
 
     const audioPlayer = el('audio', { id: 'audioPlayer', controls: '' });
+    audioPlayer.style.display = 'none';
     fabPanel.appendChild(audioPlayer);
 
     fab.addEventListener('click', function () {
@@ -307,6 +308,7 @@ hide_from_nav: true
       console.log('Matching URL: ' + matchingUrl);
       if (matchingUrl) {
         audioPlayer.src = matchingUrl;
+        audioPlayer.style.display = '';
       } else {
         console.warn('Audio file not found in selected directory: ' + relevantUrl);
       }

--- a/jekyll/tracks/index.html
+++ b/jekyll/tracks/index.html
@@ -42,6 +42,57 @@ hide_from_nav: true
     visibility: visible;
     opacity: 1;
   }
+
+  #audioFab {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 1000;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: #5a5a9a;
+    border: 2px solid #9a9adf;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 26px;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+    transition: transform 0.2s, background 0.2s, box-shadow 0.2s;
+    line-height: 1;
+  }
+  #audioFab:hover {
+    background: #7a7abf;
+    transform: scale(1.1);
+    box-shadow: 0 6px 18px rgba(0,0,0,0.6);
+  }
+  #audioFabPanel {
+    position: fixed;
+    bottom: 90px;
+    right: 24px;
+    z-index: 999;
+    background: #1e1e3a;
+    border: 1px solid #7a7abf;
+    border-radius: 14px;
+    padding: 16px 18px;
+    box-shadow: 0 8px 28px rgba(0,0,0,0.6);
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    min-width: 300px;
+    gap: 10px;
+  }
+  #audioFabPanel audio {
+    width: 100%;
+    margin-top: 4px;
+  }
+  #audioFabPanel .fab-panel-title {
+    margin: 0;
+    color: #b0b0e0;
+    font-size: 0.78em;
+    text-align: center;
+  }
 </style>
 
 <script>
@@ -203,56 +254,66 @@ hide_from_nav: true
       'Deliveries: ' + track.Deliveries.join(', ')));
   }
 
-  // ---- Audio player ----
-  const audioHr = hr();
-  audioHr.id = 'audioSectionDivider';
-  frag.appendChild(audioHr);
+  // ---- Audio player (floating FAB) ----
+  const isMobile = window.innerWidth <= 768 ||
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent);
 
-  const audioOuter = el('div', { style: 'display: flex; flex-direction: column; align-items: center; margin: 0 auto; text-align: center;' });
-  const audioCtrlContainer = el('div', { id: 'audioControlContainer', style: 'display: flex; align-items: center;' });
+  if (!isMobile) {
+    const fab = el('button', { id: 'audioFab', title: 'Listen to track', 'aria-label': 'Listen to track' });
+    fab.textContent = '\uD83C\uDFA7';
 
-  const audioLabelWrap = el('div', { style: 'display: flex; flex-direction: column; align-items: flex-start; margin-right: 10px;' });
-  const fileLabel = el('label', { for: 'fileInput', class: 'tooltip', style: 'margin-bottom: 10px; color: greenyellow;' });
-  fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
-  const tooltipSpan = el('span', { class: 'tooltiptext' });
-  tooltipSpan.textContent = 'Select the top-level directory for the collection, usually named "LPC USB"';
-  fileLabel.appendChild(tooltipSpan);
+    const fabPanel = el('div', { id: 'audioFabPanel' });
 
-  const fileInput = el('input', { type: 'file', id: 'fileInput', accept: 'audio/mp3', webkitdirectory: '', multiple: '' });
-  audioLabelWrap.appendChild(fileLabel);
-  audioLabelWrap.appendChild(fileInput);
+    const panelTitle = el('p', { class: 'fab-panel-title' });
+    panelTitle.textContent = 'Select the top-level directory for the collection, usually named \u201CLPC USB\u201D';
+    fabPanel.appendChild(panelTitle);
 
-  const audioPlayer = el('audio', { id: 'audioPlayer', controls: '' });
-  audioCtrlContainer.appendChild(audioLabelWrap);
-  audioCtrlContainer.appendChild(audioPlayer);
-  audioOuter.appendChild(audioCtrlContainer);
-  frag.appendChild(audioOuter);
-  frag.appendChild(hr());
+    const fileLabel = el('label', { for: 'fileInput', class: 'tooltip', style: 'color: greenyellow; cursor: pointer; font-weight: bold;' });
+    fileLabel.textContent = '\u2B07\uFE0F Select LPC USB \u2B07\uFE0F';
+    const tooltipSpan = el('span', { class: 'tooltiptext' });
+    tooltipSpan.textContent = 'Select the top-level directory for the collection, usually named "LPC USB"';
+    fileLabel.appendChild(tooltipSpan);
+    fabPanel.appendChild(fileLabel);
 
-  // File selection handler
-  const fileMap = {};
-  fileInput.addEventListener('change', function (event) {
-    const files = event.target.files;
-    for (const file of files) {
-      fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
-    }
-    const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
-    const relevantUrl = 'LPC USB/' + album.USB_Directory + '/' + usbFilename;
-    console.log('Relevant URL: ' + relevantUrl);
-    const matchingUrl = fileMap[relevantUrl];
-    console.log('Matching URL: ' + matchingUrl);
-    if (matchingUrl) {
-      audioPlayer.src = matchingUrl;
-    } else {
-      console.warn('Audio file not found in selected directory: ' + relevantUrl);
-    }
-  });
+    const fileInput = el('input', { type: 'file', id: 'fileInput', accept: 'audio/mp3', webkitdirectory: '', multiple: '' });
+    fabPanel.appendChild(fileInput);
 
-  // Hide audio controls on mobile
-  if (window.innerWidth <= 768 ||
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i.test(navigator.userAgent)) {
-    audioCtrlContainer.style.display = 'none';
-    audioHr.style.display = 'none';
+    const audioPlayer = el('audio', { id: 'audioPlayer', controls: '' });
+    fabPanel.appendChild(audioPlayer);
+
+    fab.addEventListener('click', function () {
+      const isOpen = fabPanel.style.display === 'flex';
+      fabPanel.style.display = isOpen ? 'none' : 'flex';
+    });
+
+    // Close panel when clicking outside
+    document.addEventListener('click', function (e) {
+      if (!fab.contains(e.target) && !fabPanel.contains(e.target)) {
+        fabPanel.style.display = 'none';
+      }
+    });
+
+    // File selection handler
+    const fileMap = {};
+    fileInput.addEventListener('change', function (event) {
+      const files = event.target.files;
+      for (const file of files) {
+        fileMap[file.webkitRelativePath] = URL.createObjectURL(file);
+      }
+      const usbFilename = track.USB_Filename || (track.Track_Title + '.mp3');
+      const relevantUrl = 'LPC USB/' + album.USB_Directory + '/' + usbFilename;
+      console.log('Relevant URL: ' + relevantUrl);
+      const matchingUrl = fileMap[relevantUrl];
+      console.log('Matching URL: ' + matchingUrl);
+      if (matchingUrl) {
+        audioPlayer.src = matchingUrl;
+      } else {
+        console.warn('Audio file not found in selected directory: ' + relevantUrl);
+      }
+    });
+
+    document.body.appendChild(fabPanel);
+    document.body.appendChild(fab);
   }
 
   // ---- Subtitles ----

--- a/jekyll/tracks/index.html
+++ b/jekyll/tracks/index.html
@@ -48,33 +48,35 @@ hide_from_nav: true
     bottom: 24px;
     right: 24px;
     z-index: 1000;
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
+    height: 48px;
+    min-width: 48px;
+    border-radius: 24px;
     background: #5a5a9a;
     border: 2px solid #9a9adf;
     cursor: pointer;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
     justify-content: center;
-    font-size: 26px;
+    gap: 6px;
+    padding: 0 14px;
+    font-size: 22px;
     box-shadow: 0 4px 14px rgba(0,0,0,0.5);
-    transition: transform 0.2s, background 0.2s, box-shadow 0.2s;
+    transition: background 0.2s, box-shadow 0.2s, min-width 0.2s;
     line-height: 1;
-    gap: 1px;
-  }
-  #audioFabTime {
-    font-size: 8px;
-    color: #d0d0ff;
-    letter-spacing: 0.02em;
-    line-height: 1;
-    display: none;
   }
   #audioFab:hover {
     background: #7a7abf;
-    transform: scale(1.1);
     box-shadow: 0 6px 18px rgba(0,0,0,0.6);
+  }
+  #audioFabTime {
+    font-size: 13px;
+    font-weight: bold;
+    color: #d0d0ff;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    display: none;
+    white-space: nowrap;
   }
   #audioFabPanel {
     position: fixed;
@@ -340,7 +342,7 @@ hide_from_nav: true
             if (audioPlayer.duration) {
               const s = Math.floor(audioPlayer.currentTime);
               fabTimeLabel.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
-              fabTimeLabel.style.display = '';
+              fabTimeLabel.style.display = 'block';
             }
           });
         } catch (e) {


### PR DESCRIPTION
This pull request moves the LPC USB audio player that was displaying on track pages to its own floating action button in the bottom right of the browser window. This button appears across all pages now. Uploading the LPC USB data now persists across pages too, so it doesn't have to be re-uploaded with each page navigation. Once an audio track is playing, it will continue to play until another track is chosen to play or if a timestamp link is clicked on the Subtitles page.